### PR TITLE
ec2のinstanceを作成して、githubのkeyでsshできるように追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 **/.terraform/*
+terraform.tfvars

--- a/buget_alert.tf
+++ b/buget_alert.tf
@@ -1,3 +1,9 @@
+variable "notification_email" {
+  description = "Email address to receive budget alerts"
+  type        = string
+}
+
+
 resource "aws_sns_topic" "budget_alert" {
   name = "budget-alert-topic"
 }
@@ -5,7 +11,7 @@ resource "aws_sns_topic" "budget_alert" {
 resource "aws_sns_topic_subscription" "email" {
   topic_arn = aws_sns_topic.budget_alert.arn
   protocol  = "email"
-  endpoint  = "moriyoshi.kasuga1218@gmail.com"
+  endpoint  = var.notification_email
 }
 
 locals {

--- a/ec2.sh
+++ b/ec2.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -Ceux
+set -o pipefail
+
+GITHUB_USERNAME="moriyoshi-kasuga"
+curl https://github.com/${GITHUB_USERNAME}.keys -o ${GITHUB_USERNAME}.keys
+
+mkdir -p /home/ubuntu/.ssh/
+mv ${GITHUB_USERNAME}.keys /home/ubuntu/.ssh/authorized_keys
+
+chmod 600 /home/ubuntu/.ssh/authorized_keys

--- a/ec2.sh
+++ b/ec2.sh
@@ -6,6 +6,9 @@ GITHUB_USERNAME="moriyoshi-kasuga"
 curl https://github.com/${GITHUB_USERNAME}.keys -o ${GITHUB_USERNAME}.keys
 
 mkdir -p /home/ubuntu/.ssh/
-mv ${GITHUB_USERNAME}.keys /home/ubuntu/.ssh/authorized_keys
+chmod 700 /home/ubuntu/.ssh/
+chown ubuntu:ubuntu /home/ubuntu/.ssh/
 
+mv ${GITHUB_USERNAME}.keys /home/ubuntu/.ssh/authorized_keys
 chmod 600 /home/ubuntu/.ssh/authorized_keys
+chown ubuntu:ubuntu /home/ubuntu/.ssh/authorized_keys

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,0 +1,30 @@
+# https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical
+}
+
+resource "aws_instance" "kdg-aws-20250621-user-date-enable" {
+  ami           = data.aws_ami.ubuntu.id
+  instance_type = "t3.micro"
+
+  tags = {
+    Name     = "kdg-aws-20250621-user-date-enable",
+    UserDate = "true"
+  }
+
+  user_data_replace_on_change = true
+
+  user_data = file("./ec2.sh")
+}

--- a/ec2.tf
+++ b/ec2.tf
@@ -24,7 +24,37 @@ resource "aws_instance" "kdg-aws-20250621-user-date-enable" {
     UserDate = "true"
   }
 
+  security_groups             = [aws_security_group.ssh_enable.name]
   user_data_replace_on_change = true
 
   user_data = file("./ec2.sh")
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC where the EC2 instance will be launched"
+  type        = string
+}
+
+data "aws_vpc" "main" {
+  id = var.vpc_id
+}
+
+resource "aws_security_group" "ssh_enable" {
+  name        = "ssh-enable"
+  description = "Allow SSH access from anywhere"
+  vpc_id      = data.aws_vpc.main.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -1,0 +1,1 @@
+notification_email = ""

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -1,1 +1,2 @@
 notification_email = ""
+vpc_id = ""


### PR DESCRIPTION
## なぜやるか
- terraformを使いec2のinstanceを作成することでより実践的な例を学ぶため。
## 追加点
- `vpc`を作成する際にidが必要だったため、ついでに前回の`notification_email`も含めた`terraform.tfvars`を作成
- `ec2.tf`を追加
  - `user_data`では`file("./ec2.sh")`のように記述することでshellscriptをファイルに分割
  - vpcを作成する際に`aws_security_group`のresourceを使い短く記述